### PR TITLE
please update the social API connecting

### DIFF
--- a/03_GettingData/02_04_readingFromAPIs/index.Rmd
+++ b/03_GettingData/02_04_readingFromAPIs/index.Rmd
@@ -76,6 +76,7 @@ sig = sign_oauth1.0(myapp,
 homeTL = GET("https://api.twitter.com/1.1/statuses/home_timeline.json", sig)
 ```
 
+##this method is no longer valid, can you update?
 
 ---
 


### PR DESCRIPTION
Hi Data Science Instructors,

I've taken the 'getting and cleaning the data' course back in 2015. Back then the relevant method to connect to twitter works, however, currently i tried it again and found the method is already out of date. Using the same exact code, i got below error: 

> [1] "Using browser based authentication"
> Error in init_oauth1.0(self$endpoint, self$app, permission = self$params$permission,  : 
> Unauthorized (HTTP 401).

Can you update the slide? If you've already done it in your new course, can you pose the solution? 

Thank you!